### PR TITLE
Added support for 16KB page size devices

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ allprojects {
 }
 
 android {
+	ndkVersion '28.1.13356709'
 	compileSdkVersion 33
 
 	defaultConfig {


### PR DESCRIPTION
I added support for the 16KB page size devices as required by Google. 
I simply configured a version of the NDK higher than r27 into the build.gradle file.